### PR TITLE
Add `SqlFootprint.exclude`

### DIFF
--- a/lib/sql_footprint.rb
+++ b/lib/sql_footprint.rb
@@ -16,6 +16,13 @@ module SqlFootprint
     end
   end
 
+  def self.exclude
+    ActiveRecord::Base.logger = @original_logger
+    yield
+  ensure
+    ActiveRecord::Base.logger = @logger
+  end
+
   class Logger
     def initialize
       @logs = []

--- a/spec/sql_footprint_spec.rb
+++ b/spec/sql_footprint_spec.rb
@@ -51,6 +51,14 @@ describe SqlFootprint do
         "\"widgets\".\"name\" = 'value-redacted'"
       expect(logger.logs.first).to eq expected
     end
+
+    it 'can exclude some statements' do
+      Widget.where(name: SecureRandom.uuid).last
+      widget = described_class.exclude { Widget.create! }
+      expect(widget).to be_a(Widget)
+      expect(logger.logs.length).to eq 1
+      expect(logger.logs.first).to start_with('SELECT')
+    end
   end
 
   describe '.stop' do


### PR DESCRIPTION
Allowing an application's test suite to exclude the db setup tasks.

closes #1