### PR TITLE
Add ability to filter sql statements

### DIFF
--- a/lib/sql_footprint.rb
+++ b/lib/sql_footprint.rb
@@ -1,5 +1,6 @@
 require 'sql_footprint/version'
 require 'sql_footprint/sql_anonymizer'
+require 'sql_footprint/sql_filter'
 require 'set'
 require 'active_support/notifications'
 
@@ -14,6 +15,7 @@ module SqlFootprint
   class << self
     def start
       @anonymizer = SqlAnonymizer.new
+      @filter     = SqlFilter.new
       @capture    = true
       @lines      = Set.new
     end
@@ -35,7 +37,7 @@ module SqlFootprint
     end
 
     def capture sql
-      return unless @capture
+      return unless @capture && @filter.capture?(sql)
       @lines << @anonymizer.anonymize(sql)
     end
   end

--- a/lib/sql_footprint/sql_filter.rb
+++ b/lib/sql_footprint/sql_filter.rb
@@ -1,7 +1,7 @@
 module SqlFootprint
   class SqlFilter
     EXCLUDE_REGEXS = [
-      /^SHOW .*$/
+      /\ASHOW\s/
     ].freeze
 
     def capture? sql

--- a/lib/sql_footprint/sql_filter.rb
+++ b/lib/sql_footprint/sql_filter.rb
@@ -1,0 +1,11 @@
+module SqlFootprint
+  class SqlFilter
+    EXCLUDE_REGEXS = [
+      /^SHOW .*$/
+    ].freeze
+
+    def capture? sql
+      EXCLUDE_REGEXS.none? { |regex| regex =~ sql }
+    end
+  end
+end

--- a/spec/sql_footprint/sql_filter_spec.rb
+++ b/spec/sql_footprint/sql_filter_spec.rb
@@ -8,7 +8,7 @@ describe SqlFootprint::SqlFilter do
     expect(filter.capture?(query)).to be_falsey
   end
 
-  ['SELECT', 'INSERT', 'UPDATE', 'DELETE'].each do |prefix|
+  %w(SELECT INSERT UPDATE DELETE).each do |prefix|
     it "does not filter #{prefix} queries" do
       query = "#{prefix} #{SecureRandom.uuid}"
       expect(filter.capture?(query)).to be_truthy

--- a/spec/sql_footprint/sql_filter_spec.rb
+++ b/spec/sql_footprint/sql_filter_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe SqlFootprint::SqlFilter do
+  let(:filter) { described_class.new }
+
+  it 'filters out SHOW queries' do
+    query = "SHOW #{SecureRandom.uuid}"
+    expect(filter.capture?(query)).to be_falsey
+  end
+
+  ['SELECT', 'INSERT', 'UPDATE', 'DELETE'].each do |prefix|
+    it "does not filter #{prefix} queries" do
+      query = "#{prefix} #{SecureRandom.uuid}"
+      expect(filter.capture?(query)).to be_truthy
+    end
+  end
+end

--- a/spec/sql_footprint_spec.rb
+++ b/spec/sql_footprint_spec.rb
@@ -69,9 +69,10 @@ describe SqlFootprint do
     it 'does not write SHOW queries' do
       begin
         Widget.connection.execute("SHOW #{SecureRandom.uuid}")
-      rescue # We don't care about the validity of the SQL
+      rescue
+        "We don't care about the validity of the SQL" # rubocop
       end
-      expect(described_class.lines.join).not_to include "SHOW"
+      expect(described_class.lines.join).not_to include 'SHOW'
     end
   end
 

--- a/spec/sql_footprint_spec.rb
+++ b/spec/sql_footprint_spec.rb
@@ -65,6 +65,14 @@ describe SqlFootprint do
       end.to change { described_class.lines.length }.by(+1)
       expect(described_class.lines.join).not_to include 'INSERT INTO \"widgets\"'
     end
+
+    it 'does not write SHOW queries' do
+      begin
+        Widget.connection.execute("SHOW #{SecureRandom.uuid}")
+      rescue # We don't care about the validity of the SQL
+      end
+      expect(described_class.lines.join).not_to include "SHOW"
+    end
   end
 
   describe '.stop' do


### PR DESCRIPTION
One of our applications has failing CI build because of `SHOW` queries that are not consistently run. This allows us to manually exclude some queries. I think this is good enough for V1, but down the road we might want to consider allow the client to subscribe/unsubscribe from some filtering rules.