### PR TITLE
Setup SqlStatements container

### DIFF
--- a/lib/sql_footprint/sql_statements.rb
+++ b/lib/sql_footprint/sql_statements.rb
@@ -3,7 +3,6 @@ require 'active_support/core_ext/module/delegation'
 
 module SqlFootprint
   class SqlStatements
-
     def initialize
       @statements = Set.new
     end

--- a/lib/sql_footprint/sql_statements.rb
+++ b/lib/sql_footprint/sql_statements.rb
@@ -1,0 +1,17 @@
+require 'set'
+require 'active_support/core_ext/module/delegation'
+
+module SqlFootprint
+  class SqlStatements
+
+    def initialize
+      @statements = Set.new
+    end
+
+    delegate :to_a, :add, :sort, :count, to: :statements
+
+    private
+
+    attr_reader :statements
+  end
+end

--- a/spec/sql_footprint/sql_statements_spec.rb
+++ b/spec/sql_footprint/sql_statements_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 RSpec.describe SqlFootprint::SqlStatements do
-
   let(:sql_statements) { described_class.new }
 
   describe '#to_a' do
@@ -36,7 +35,6 @@ RSpec.describe SqlFootprint::SqlStatements do
         expect(sql_statements.to_a).to eq statements
       end
     end
-
   end
 
   describe '#add' do
@@ -58,10 +56,10 @@ RSpec.describe SqlFootprint::SqlStatements do
       end
     end
 
-    let(:statements) { ['b', 'c', 'a'] }
+    let(:statements) { %w(b c a) }
 
     it 'sorts the statements given' do
-      expect(statements.sort).to eq ['a', 'b', 'c']
+      expect(statements.sort).to eq %w(a b c)
     end
   end
 

--- a/spec/sql_footprint/sql_statements_spec.rb
+++ b/spec/sql_footprint/sql_statements_spec.rb
@@ -1,0 +1,101 @@
+require 'spec_helper'
+
+RSpec.describe SqlFootprint::SqlStatements do
+
+  let(:sql_statements) { described_class.new }
+
+  describe '#to_a' do
+    before do
+      statements.each do |statement|
+        sql_statements.add statement
+      end
+    end
+
+    context 'no statements' do
+      let(:statements) { [] }
+
+      it 'returns an empty array' do
+        expect(sql_statements.to_a).to eq statements
+      end
+    end
+
+    context 'one statement' do
+      let(:statements) { [SecureRandom.hex] }
+
+      it 'returns an array with one statement' do
+        expect(sql_statements.to_a).to eq statements
+      end
+    end
+
+    context 'multiple statements' do
+      let(:statements) do
+        Array.new(3) { SecureRandom.hex }
+      end
+
+      it 'returns all of the statements given' do
+        expect(sql_statements.to_a).to eq statements
+      end
+    end
+
+  end
+
+  describe '#add' do
+    before do
+      sql_statements.add statement
+    end
+
+    let(:statement) { SecureRandom.hex }
+
+    it 'adds the sql statement to the collection' do
+      expect(sql_statements.to_a).to include statement
+    end
+  end
+
+  describe '#sort' do
+    before do
+      statements.each do |statement|
+        sql_statements.add statement
+      end
+    end
+
+    let(:statements) { ['b', 'c', 'a'] }
+
+    it 'sorts the statements given' do
+      expect(statements.sort).to eq ['a', 'b', 'c']
+    end
+  end
+
+  describe '#count' do
+    before do
+      statements.each do |statement|
+        sql_statements.add statement
+      end
+    end
+
+    context 'no statements' do
+      let(:statements) { [] }
+
+      it 'returns 0' do
+        expect(sql_statements.count).to eq 0
+      end
+    end
+
+    context 'one statement' do
+      let(:statements) { [SecureRandom.hex] }
+
+      it 'returns 1' do
+        expect(sql_statements.count).to eq 1
+      end
+    end
+
+    context 'three statements' do
+      let(:statements) do
+        Array.new(3) { SecureRandom.hex }
+      end
+
+      it 'returns 3' do
+        expect(sql_statements.count).to eq 3
+      end
+    end
+  end
+end


### PR DESCRIPTION
This uses our own SqlStatements container instead of a generalized container such as a `Set` or `Array`.  This is a good idea because it gives us more control over the object we use to store the sql statements being captured (which is part of the public interface) without having to worry about breaking client code (as long as we still implement the same interface).

This is a breaking change. 