### PR TITLE
Split footprints by database name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /spec/reports/
 /tmp/
 footprint.sql
+footprint.:memory:.sql

--- a/History.md
+++ b/History.md
@@ -1,0 +1,5 @@
+
+1.0.0 / 2016-05-04
+==================
+
+  * Split footprint files by database name

--- a/lib/sql_footprint/footprint_serializer.rb
+++ b/lib/sql_footprint/footprint_serializer.rb
@@ -1,0 +1,13 @@
+module SqlFootprint
+  class FootprintSerializer
+    NEWLINE = "\n".freeze
+
+    def initialize statements
+      @statements = statements
+    end
+
+    def to_s
+      @statements.sort.join(NEWLINE) + NEWLINE
+    end
+  end
+end

--- a/lib/sql_footprint/sql_capturer.rb
+++ b/lib/sql_footprint/sql_capturer.rb
@@ -1,0 +1,33 @@
+require 'sql_footprint/footprint_serializer'
+
+module SqlFootprint
+  class SqlCapturer
+    attr_reader :statements, :database_name
+
+    def initialize database_name
+      @anonymizer   = SqlAnonymizer.new
+      @filter       = SqlFilter.new
+      @statements   = SqlStatements.new
+      @database_name = database_name
+    end
+
+    def capture sql
+      return unless @filter.capture?(sql)
+      @statements.add @anonymizer.anonymize(sql)
+    end
+
+    def write
+      File.write filename, serialized_statements
+    end
+
+    private
+
+    def serialized_statements
+      SqlFootprint::FootprintSerializer.new(statements).to_s
+    end
+
+    def filename
+      "footprint.#{database_name.split('/').last}.sql"
+    end
+  end
+end

--- a/lib/sql_footprint/version.rb
+++ b/lib/sql_footprint/version.rb
@@ -1,3 +1,3 @@
 module SqlFootprint
-  VERSION = '0.8.0'.freeze
+  VERSION = '1.0.0'.freeze
 end

--- a/spec/sql_footprint/footprint_serializer_spec.rb
+++ b/spec/sql_footprint/footprint_serializer_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+RSpec.describe SqlFootprint::FootprintSerializer do
+  describe '#to_s' do
+    let(:sql_statements) { SqlFootprint::SqlStatements.new }
+    let(:statements) do
+      Array.new(3) { SecureRandom.hex }
+    end
+
+    before do
+      statements.each do |statement|
+        sql_statements.add statement
+      end
+    end
+
+    it 'sorts and joins the statements into a string' do
+      expect(described_class.new(sql_statements).to_s).to eq(statements.sort.join("\n") + "\n")
+    end
+  end
+end

--- a/spec/sql_footprint/sql_capturer_spec.rb
+++ b/spec/sql_footprint/sql_capturer_spec.rb
@@ -1,0 +1,86 @@
+require 'spec_helper'
+
+describe SqlFootprint::SqlCapturer do
+  let(:db_name) { SecureRandom.uuid }
+  let(:serialized_statements) { SecureRandom.uuid }
+  describe '#initialize' do
+    it 'requires db_name' do
+      expect { described_class.new }.to raise_error ArgumentError
+    end
+
+    it 'sets the database_name' do
+      described_class.new(db_name).tap do |capturer|
+        expect(capturer.database_name).to eq db_name
+      end
+    end
+  end
+
+  before do
+    allow(SqlFootprint::SqlFilter).to receive(:new).and_return(sql_filter_double)
+    allow(SqlFootprint::SqlAnonymizer).to receive(:new).and_return(sql_anonymizer_double)
+    allow(SqlFootprint::SqlStatements).to receive(:new).and_return(sql_statements_double)
+    allow(SqlFootprint::FootprintSerializer).to receive(:new).with(sql_statements_double)
+      .and_return(footprint_serializer_double)
+  end
+
+  let(:sql_filter_double) do
+    double('SqlFilter').tap do |d|
+      allow(d).to receive(:capture?).with(sql).and_return(should_capture)
+    end
+  end
+  let(:sql_anonymizer_double) do
+    double('SqlAnonymizer').tap do |d|
+      allow(d).to receive(:anonymize).with(sql).and_return(anonymized_sql)
+    end
+  end
+  let(:sql_statements_double) do
+    double('SqlStatements')
+  end
+  let(:footprint_serializer_double) do
+    double('SqlStatementsSearializer').tap do |d|
+      allow(d).to receive(:to_s).and_return(serialized_statements)
+    end
+  end
+
+  let(:sql) { SecureRandom.uuid }
+  let(:anonymized_sql) { SecureRandom.uuid }
+  let(:should_capture) { true }
+
+  describe '#capture' do
+    subject { described_class.new(db_name) }
+
+    context 'when the SqlFilter returns false' do
+      let(:should_capture) { false }
+
+      it 'does not add the statement' do
+        expect(sql_statements_double).not_to receive(:add)
+        subject.capture(sql)
+      end
+    end
+
+    context 'when the SqlFilter returns true' do
+      let(:should_capture) { true }
+
+      it 'does add the statement' do
+        expect(sql_statements_double).to receive(:add).with(anonymized_sql)
+        subject.capture(sql)
+      end
+    end
+  end
+
+  describe '#write' do
+    subject { described_class.new(db_name) }
+
+    it 'writes the serialized statements to the contents of a file' do
+      expect(footprint_serializer_double).to receive(:to_s)
+        .and_return(serialized_statements)
+      expect(File).to receive(:write).with(anything, serialized_statements)
+      subject.write
+    end
+
+    it 'writes to db-specific filename' do
+      expect(File).to receive(:write).with("footprint.#{db_name}.sql", anything)
+      subject.write
+    end
+  end
+end


### PR DESCRIPTION
This would result in per-database footprints.  For example, if you're using DB1 AND DB2 in your app, you would end up with two footprint files. (footprint.db1.sql, footprint.db2.sql)

This should be useful if you have a mixed environment and need to avoid the confusion that a combined footprint might cause. Also works across multiple adapters. 