### PR TITLE
Allow Rails 3+ usage

### DIFF
--- a/lib/sql_footprint/version.rb
+++ b/lib/sql_footprint/version.rb
@@ -1,3 +1,3 @@
 module SqlFootprint
-  VERSION = '1.0.0'.freeze
+  VERSION = '1.0.1'.freeze
 end

--- a/sql_footprint.gemspec
+++ b/sql_footprint.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activerecord', '>= 3.0'
-  spec.add_dependency 'activesupport', '>= 3.0'
+  spec.add_dependency 'activerecord', ['>= 3.0', '< 6.0']
+  spec.add_dependency 'activesupport', ['>= 3.0', '< 6.0']
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/sql_footprint.gemspec
+++ b/sql_footprint.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activerecord', '~> 4.0'
-  spec.add_dependency 'activesupport', '~> 4.0'
+  spec.add_dependency 'activerecord', '>= 3.0'
+  spec.add_dependency 'activesupport', '>= 3.0'
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
I think we can relax this dependency.  Everything still seems to work.  

If you force Rails to 3 some of the tests fail due to slightly different generated sql, but it's not really breaking anything.  

@mikegee @schneiderderek Thoughts on this?