### PR TITLE
Fix VALUES clause in INSERT statements when not using prepared statements

### DIFF
--- a/lib/sql_footprint/sql_anonymizer.rb
+++ b/lib/sql_footprint/sql_anonymizer.rb
@@ -4,6 +4,7 @@ module SqlFootprint
       /\sIN\s\((.*)\)/ => ' IN (values-redacted)'.freeze, # IN clauses
       /\s'(.*)\'/ => " 'value-redacted'".freeze, # literal strings
       /\s+(!=|=|<|>|<=|>=)\s+[0-9]+/ => ' \1 number-redacted', # numbers
+      /\s+VALUES\s+\(.+\)/ => ' VALUES (values-redacted)', # VALUES
     }.freeze
 
     def anonymize sql

--- a/spec/sql_footprint/sql_anonymizer_spec.rb
+++ b/spec/sql_footprint/sql_anonymizer_spec.rb
@@ -5,9 +5,9 @@ describe SqlFootprint::SqlAnonymizer do
 
   it 'formats INSERT statements' do
     sql = 'INSERT INTO "widgets" ("created_at", "name") VALUES ' \
-    "'2016-05-1 6 19:16:04.981048', 12345) RETURNING \"id\""
+    "('2016-05-1 6 19:16:04.981048', 12345) RETURNING \"id\""
     expect(anonymizer.anonymize(sql)).to eq 'INSERT INTO "widgets" ' \
-    '("created_at", "name") VALUES (values-redacted) RETURNING \"id\"'
+    '("created_at", "name") VALUES (values-redacted) RETURNING "id"'
   end
 
   it 'formats IN clauses' do

--- a/spec/sql_footprint/sql_anonymizer_spec.rb
+++ b/spec/sql_footprint/sql_anonymizer_spec.rb
@@ -4,8 +4,10 @@ describe SqlFootprint::SqlAnonymizer do
   let(:anonymizer) { described_class.new }
 
   it 'formats INSERT statements' do
-    sql = %q{INSERT INTO "widgets" ("created_at", "name") VALUES ('2016-05-1 6 19:16:04.981048', 12345) RETURNING "id"}
-    expect(anonymizer.anonymize(sql)).to eq %q{INSERT INTO "widgets" ("created_at", "name") VALUES (values-redacted) RETURNING "id"}
+    sql = 'INSERT INTO "widgets" ("created_at", "name") VALUES ' +
+    %q{('2016-05-1 6 19:16:04.981048', 12345) RETURNING "id"}
+    expect(anonymizer.anonymize(sql)).to eq 'INSERT INTO "widgets" ' +
+    '("created_at", "name") VALUES (values-redacted) RETURNING "id"'
   end
 
   it 'formats IN clauses' do

--- a/spec/sql_footprint/sql_anonymizer_spec.rb
+++ b/spec/sql_footprint/sql_anonymizer_spec.rb
@@ -3,6 +3,11 @@ require 'spec_helper'
 describe SqlFootprint::SqlAnonymizer do
   let(:anonymizer) { described_class.new }
 
+  it 'formats INSERT statements' do
+    sql = %q{INSERT INTO "widgets" ("created_at", "name") VALUES ('2016-05-1 6 19:16:04.981048', 12345) RETURNING "id"}
+    expect(anonymizer.anonymize(sql)).to eq %q{INSERT INTO "widgets" ("created_at", "name") VALUES (values-redacted) RETURNING "id"}
+  end
+
   it 'formats IN clauses' do
     sql = Widget.where(name: [SecureRandom.uuid, SecureRandom.uuid]).to_sql
     expect(anonymizer.anonymize(sql)).to eq(

--- a/spec/sql_footprint/sql_anonymizer_spec.rb
+++ b/spec/sql_footprint/sql_anonymizer_spec.rb
@@ -4,10 +4,10 @@ describe SqlFootprint::SqlAnonymizer do
   let(:anonymizer) { described_class.new }
 
   it 'formats INSERT statements' do
-    sql = 'INSERT INTO "widgets" ("created_at", "name") VALUES ' +
-    %q{('2016-05-1 6 19:16:04.981048', 12345) RETURNING "id"}
-    expect(anonymizer.anonymize(sql)).to eq 'INSERT INTO "widgets" ' +
-    '("created_at", "name") VALUES (values-redacted) RETURNING "id"'
+    sql = 'INSERT INTO "widgets" ("created_at", "name") VALUES ' \
+    "'2016-05-1 6 19:16:04.981048', 12345) RETURNING \"id\""
+    expect(anonymizer.anonymize(sql)).to eq 'INSERT INTO "widgets" ' \
+    '("created_at", "name") VALUES (values-redacted) RETURNING \"id\"'
   end
 
   it 'formats IN clauses' do

--- a/spec/sql_footprint_spec.rb
+++ b/spec/sql_footprint_spec.rb
@@ -24,7 +24,7 @@ describe SqlFootprint do
     it 'formats inserts' do
       Widget.create!
       expect(statements.to_a).to include(
-        'INSERT INTO "widgets" ("created_at", "updated_at") VALUES (?, ?)'
+        'INSERT INTO "widgets" ("created_at", "updated_at") VALUES (values-redacted)'
       )
     end
 


### PR DESCRIPTION
When i turned off prepared statements in one of our applications I saw that the VALUES clause for INSERT statements were not being anonymized correctly.

Abbreviated Ex:
```sql
INSERT INTO "table" ("created_at", "id", "updated_at") VALUES ('2016-05-16 19:16:05.602655', 'value-redacted') RETURNING "id"
```

This PR fixes that.

Note: when PG dbs still using prepared statements run this they will see the following changes in their sql footprint:

```sql
'INSERT INTO "widgets" ("created_at", "updated_at") VALUES (?, ?)'
```

TO:
```sql
'INSERT INTO "widgets" ("created_at", "updated_at") VALUES (values-redacted)'
```

