### PR TITLE
Filter out queries for internal pg_* tables

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,9 @@ require: rubocop-rspec
 Style/MethodDefParentheses:
   EnforcedStyle: require_no_parentheses
 
+Style/TrailingCommaInLiteral:
+  Enabled: false
+
 Metrics/LineLength:
   Max: 100
 

--- a/lib/sql_footprint/sql_filter.rb
+++ b/lib/sql_footprint/sql_filter.rb
@@ -1,7 +1,8 @@
 module SqlFootprint
   class SqlFilter
     EXCLUDE_REGEXS = [
-      /\ASHOW\s/
+      /\ASHOW\s/,
+      /FROM\s+pg_/,
     ].freeze
 
     def capture? sql

--- a/spec/sql_footprint/sql_filter_spec.rb
+++ b/spec/sql_footprint/sql_filter_spec.rb
@@ -8,6 +8,18 @@ describe SqlFootprint::SqlFilter do
     expect(filter.capture?(query)).to be_falsey
   end
 
+  it 'filters out internal pg_*tables' do
+    query = <<-EOSQL
+      SELECT COUNT(*)
+      FROM pg_class c
+      LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE c.relkind in ('v','r')
+      AND c.relname = 'value-redacted'
+      AND n.nspname = ANY (current_schemas(false))
+    EOSQL
+    expect(filter.capture?(query)).to be_falsey
+  end
+
   %w(SELECT INSERT UPDATE DELETE).each do |prefix|
     it "does not filter #{prefix} queries" do
       query = "#{prefix} #{SecureRandom.uuid}"


### PR DESCRIPTION
Queries on these tables are creating a lot of noise in my footprint. Sometimes they show up and then they disappear the next time I run the specs. There is an example of one case in the spec that I wrote. This PR filters out anything that has matches `/FROM\s+pg_/`. 

What do you guys think @mikegee @brandonjoyce ?