### PR TITLE
Handle MSSQL string literals

### DIFF
--- a/lib/sql_footprint/sql_anonymizer.rb
+++ b/lib/sql_footprint/sql_anonymizer.rb
@@ -1,8 +1,9 @@
 module SqlFootprint
   class SqlAnonymizer
     GSUBS = {
-      /\sIN\s\((.*)\)/ => ' IN (values-redacted)'.freeze, # IN clauses
-      /([\s\(])'(.*)'/ => "\\1'value-redacted'".freeze, # literal strings
+      /\sIN\s\(.*\)/ => ' IN (values-redacted)'.freeze, # IN clauses
+      /([\s\(])'.*'/ => "\\1'value-redacted'".freeze, # literal strings
+      /N''.*''/ => "N''value-redacted''".freeze, # literal MSSQL strings
       /\s+(!=|=|<|>|<=|>=)\s+[0-9]+/ => ' \1 number-redacted', # numbers
       /\s+VALUES\s+\(.+\)/ => ' VALUES (values-redacted)', # VALUES
     }.freeze

--- a/spec/sql_footprint/sql_anonymizer_spec.rb
+++ b/spec/sql_footprint/sql_anonymizer_spec.rb
@@ -57,4 +57,12 @@ describe SqlFootprint::SqlAnonymizer do
       'WHERE (name = LOWER(\'value-redacted\'))'
     )
   end
+
+  it 'formats unicode string literals for MSSQL' do
+    sql = Widget.where("name = N''whatever''").to_sql
+    expect(anonymizer.anonymize(sql)).to eq(
+      'SELECT "widgets".* FROM "widgets" ' \
+      'WHERE (name = N\'\'value-redacted\'\')'
+    )
+  end
 end


### PR DESCRIPTION
I'm getting lines like this:

```sql
SELECT [faxes].* FROM [faxes] WHERE (uuid = N''75f3d616-7d61-42a0-a6b7-558ace0aa82b'')
```