### PR TITLE
Fixing issue w/ newer versions of sql adapter

### DIFF
--- a/lib/sql_footprint.rb
+++ b/lib/sql_footprint.rb
@@ -9,10 +9,8 @@ module SqlFootprint
   ActiveSupport::Notifications.subscribe('sql.active_record') do |_, _, _, _, payload|
     if @capture
       adapter = ObjectSpace._id2ref(payload.fetch(:connection_id))
-      config = adapter.instance_variable_get(:@config)
-      if config.nil?
-        config = adapter.instance_variable_get(:@connection_options)
-      end
+      config = adapter.instance_variable_get(:@config) ||
+               adapter.instance_variable_get(:@connection_options)
       database_name = config.fetch(:database)
       capturers[database_name].capture payload.fetch(:sql)
     end

--- a/lib/sql_footprint.rb
+++ b/lib/sql_footprint.rb
@@ -9,7 +9,11 @@ module SqlFootprint
   ActiveSupport::Notifications.subscribe('sql.active_record') do |_, _, _, _, payload|
     if @capture
       adapter = ObjectSpace._id2ref(payload.fetch(:connection_id))
-      database_name = adapter.instance_variable_get(:@config).fetch(:database)
+      config = adapter.instance_variable_get(:@config)
+      if config.nil?
+        config = adapter.instance_variable_get(:@connection_options)
+      end
+      database_name = config.fetch(:database)
       capturers[database_name].capture payload.fetch(:sql)
     end
   end


### PR DESCRIPTION
We came across this when upgrading our version of activerecord-sqlserver-adapter gem.  This fix seems to work.  

The newer version moved the instance variable to connection_options rather than config. 