### PR TITLE
Allow custom rules in the SqlAnonymizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ SqlFootprint.start
 Minitest.after_run { SqlFootprint.stop }
 ```
 
+You can also add a Custom rule to SqlAnonymizer before running `start`:
+```ruby
+RSpec.configure do |config|
+  SqlFootprint::SqlAnonymizer.add_rule(/SELECT (.+) AS (.+)/, 'SELECT [redacted] AS [redacted]')
+  config.before(:suite) { SqlFootprint.start }
+  config.after(:suite) { SqlFootprint.stop }
+end
+```
+
 #### Outputs
 After running your specs you'll find a 'footprint.*.sql' file in your project.
 Footprints are per-database. For example, if you're using DB1 AND DB2 in your app, you would end up with two footprint files. (footprint.db1.sql, footprint.db2.sql)

--- a/lib/sql_footprint/sql_anonymizer.rb
+++ b/lib/sql_footprint/sql_anonymizer.rb
@@ -1,16 +1,24 @@
 module SqlFootprint
   class SqlAnonymizer
-    GSUBS = {
+    @rules = {
       /\sIN\s\(.*\)/ => ' IN (values-redacted)'.freeze, # IN clauses
       /([\s\(])'.*'/ => "\\1'value-redacted'".freeze, # literal strings
       /N''.*''/ => "N''value-redacted''".freeze, # literal MSSQL strings
-      /\s+(!=|=|<|>|<=|>=)\s+[0-9]+/ => ' \1 number-redacted', # numbers
-      /\s+VALUES\s+\(.+\)/ => ' VALUES (values-redacted)', # VALUES
-    }.freeze
+      /\s+(!=|=|<|>|<=|>=)\s+[0-9]+/ => ' \1 number-redacted'.freeze, # numbers
+      /\s+VALUES\s+\(.+\)/ => ' VALUES (values-redacted)'.freeze, # VALUES
+    }
 
     def anonymize sql
-      GSUBS.reduce(sql) do |s, (regex, replacement)|
+      self.class.rules.reduce(sql) do |s, (regex, replacement)|
         s.gsub regex, replacement
+      end
+    end
+
+    class << self
+      attr_reader :rules
+
+      def add_rule regex, replacement
+        @rules[regex] = replacement
       end
     end
   end

--- a/spec/sql_footprint/sql_anonymizer_spec.rb
+++ b/spec/sql_footprint/sql_anonymizer_spec.rb
@@ -65,4 +65,17 @@ describe SqlFootprint::SqlAnonymizer do
       'WHERE (name = N\'\'value-redacted\'\')'
     )
   end
+
+  context 'with a custom rule' do
+    let(:redacted) { 'SELECT [redacted] AS [redacted]'.freeze }
+
+    before do
+      described_class.add_rule(/SELECT .+ AS .+/, redacted)
+    end
+
+    it 'formats as expected' do
+      sql = 'SELECT some_thing AS other_thing'
+      expect(anonymizer.anonymize(sql)).to eq(redacted)
+    end
+  end
 end

--- a/spec/sql_footprint_spec.rb
+++ b/spec/sql_footprint_spec.rb
@@ -71,6 +71,20 @@ describe SqlFootprint do
       end
       expect(statements.to_a.join).not_to include 'SHOW'
     end
+
+    context 'with a custom rule' do
+      let(:redacted) { '[redacted]'.freeze }
+
+      before do
+        described_class::SqlAnonymizer.add_rule(/SELECT .+ FROM .+/, redacted)
+      end
+
+      it 'formats as expected' do
+        Widget.find_by(id: 9001)
+
+        expect(statements.to_a).to include(redacted)
+      end
+    end
   end
 
   describe '.stop' do


### PR DESCRIPTION
This will allow applications to define domain-specific rules for the Anonymizer when it doesn't makes sense to include them in the main gem.

### Example

```ruby
SqlFootprint::SqlAnonymizer.add_rule(/SELECT (.+) AS (.+)/, 'SELECT [redacted] AS [redacted]')
```