### PR TITLE
Update Ruby versions tested in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,12 @@
+sudo: false
+cache: bundler
 language: ruby
 script:
   - bundle exec rspec
   - bundle exec rubocop --display-cop-names
-sudo: false
 rvm:
-  - 1.9.3
-  - 2.0.0
+  - 2.0
   - 2.1
   - 2.2
-  - 2.3.0
-  - rbx
-matrix:
-  allow_failures:
-    - rvm: rbx
+  - 2.3
+  - 2.4


### PR DESCRIPTION
- run tests on Ruby 2.4
- drop support for Ruby 1.9
- drop support for Rubinius