### PR TITLE
Support rails5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,5 @@ script:
   - bundle exec rspec
   - bundle exec rubocop --display-cop-names
 rvm:
-  - 2.0
-  - 2.1
-  - 2.2
   - 2.3
   - 2.4

--- a/lib/sql_footprint/version.rb
+++ b/lib/sql_footprint/version.rb
@@ -1,3 +1,3 @@
 module SqlFootprint
-  VERSION = '1.2.0'.freeze
+  VERSION = '2.0.0'.freeze
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,7 @@ load File.dirname(__FILE__) + '/schema.rb'
 require File.dirname(__FILE__) + '/models.rb'
 
 rails5 = `bundle show activerecord`.strip.split('/').last =~ /activerecord-5\./
-exclude_rails = rails5 ? 4 : 5  # don't run tests for the version of rails we are NOT using
+exclude_rails = rails5 ? 4 : 5 # don't run tests for the version of rails we are NOT using
 
 RSpec.configure do |config|
   config.filter_run_excluding rails: exclude_rails

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,3 +9,10 @@ ActiveRecord::Base.establish_connection adapter: 'sqlite3', database: ':memory:'
 
 load File.dirname(__FILE__) + '/schema.rb'
 require File.dirname(__FILE__) + '/models.rb'
+
+rails5 = `bundle show activerecord`.strip.split('/').last =~ /activerecord-5\./
+exclude_rails = rails5 ? 4 : 5  # don't run tests for the version of rails we are NOT using
+
+RSpec.configure do |config|
+  config.filter_run_excluding rails: exclude_rails
+end

--- a/spec/sql_footprint_spec.rb
+++ b/spec/sql_footprint_spec.rb
@@ -28,13 +28,23 @@ describe SqlFootprint do
       )
     end
 
-    it 'formats selects' do
+    it 'formats selects', rails: 4 do
       Widget.where(name: SecureRandom.uuid, quantity: 1).last
       expect(statements.to_a).to include(
         'SELECT  "widgets".* FROM "widgets" ' \
         'WHERE "widgets"."name" = ? AND ' \
         '"widgets"."quantity" = ?  ' \
         'ORDER BY "widgets"."id" DESC LIMIT 1'
+      )
+    end
+
+    it 'formats selects', rails: 5 do
+      Widget.where(name: SecureRandom.uuid, quantity: 1).last
+      expect(statements.to_a).to include(
+        'SELECT  "widgets".* FROM "widgets" ' \
+        'WHERE "widgets"."name" = ? AND ' \
+        '"widgets"."quantity" = ?  ' \
+        'ORDER BY "widgets"."id" DESC LIMIT ?'
       )
     end
 

--- a/spec/sql_footprint_spec.rb
+++ b/spec/sql_footprint_spec.rb
@@ -33,7 +33,7 @@ describe SqlFootprint do
       expect(statements.to_a).to include(
         'SELECT  "widgets".* FROM "widgets" ' \
         'WHERE "widgets"."name" = ? AND ' \
-        '"widgets"."quantity" = ?  ' \
+        '"widgets"."quantity" = ? ' \
         'ORDER BY "widgets"."id" DESC LIMIT 1'
       )
     end
@@ -43,7 +43,7 @@ describe SqlFootprint do
       expect(statements.to_a).to include(
         'SELECT  "widgets".* FROM "widgets" ' \
         'WHERE "widgets"."name" = ? AND ' \
-        '"widgets"."quantity" = ?  ' \
+        '"widgets"."quantity" = ? ' \
         'ORDER BY "widgets"."id" DESC LIMIT ?'
       )
     end

--- a/spec/sql_footprint_spec.rb
+++ b/spec/sql_footprint_spec.rb
@@ -33,7 +33,7 @@ describe SqlFootprint do
       expect(statements.to_a).to include(
         'SELECT  "widgets".* FROM "widgets" ' \
         'WHERE "widgets"."name" = ? AND ' \
-        '"widgets"."quantity" = ? ' \
+        '"widgets"."quantity" = ?  ' \
         'ORDER BY "widgets"."id" DESC LIMIT 1'
       )
     end

--- a/sql_footprint.gemspec
+++ b/sql_footprint.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activerecord', ['>= 3.0', '< 5.0']
-  spec.add_dependency 'activesupport', ['>= 3.0', '< 5.0']
+  spec.add_dependency 'activerecord', ['>= 3.0']
+  spec.add_dependency 'activesupport', ['>= 3.0']
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Adds support for rails 5, or rather, removes the lack of support we previously had.

The testing matrix is kind of a mess so this also updates the Travis config to always run on ruby 2.3 or higher, so that rails 5 is supported and can be tested.

It turns out that there are some subtle differences in the SQL queries actually created by activerecord 4 versus activerecord 5, and so one of the specs had to be updated to support both versions, based off a tag specifying the compatible rails version.

Due to the fact that we are eliminating support for certain ruby versions, I have marked this as a major version bump.