### PR TITLE
Support multi-line values

### DIFF
--- a/lib/sql_footprint/sql_anonymizer.rb
+++ b/lib/sql_footprint/sql_anonymizer.rb
@@ -5,7 +5,7 @@ module SqlFootprint
       /([\s\(])'.*'/ => "\\1'value-redacted'".freeze, # literal strings
       /N''.*''/ => "N''value-redacted''".freeze, # literal MSSQL strings
       /\s+(!=|=|<|>|<=|>=)\s+[0-9]+/ => ' \1 number-redacted'.freeze, # numbers
-      /\s+VALUES\s+\(.+\)/ => ' VALUES (values-redacted)'.freeze, # VALUES
+      /\s+VALUES\s+\(.*?\)/m => ' VALUES (values-redacted)'.freeze, # VALUES
     }
 
     def anonymize sql


### PR DESCRIPTION
```sql
 INSERT INTO "audit_records" ("row_id", "column_id", "event_type", "user", "created_at", "transaction_id") VALUES (values-redacted) RETURNING "id"
INSERT INTO "audit_records" ("row_id", "column_id", "event_type", "user", "new_value", "created_at", "transaction_id") VALUES (40, 16118, 'value-redacted'HFEzuSwT9IhijckAuVW7Xg==
|1bLZ4PtCsuTzoQRGchX9Cw==
'value-redacted', 24646) RETURNING "id"
 INSERT INTO "audit_records" ("row_id", "column_id", "event_type", "user", "new_value", "created_at", "transaction_id") VALUES (values-redacted) RETURNING "id"
 INSERT INTO "audit_records" ("row_id", "column_id", "event_type", "user", "old_value", "created_at", "transaction_id") VALUES (values-redacted) RETURNING "id"
 INSERT INTO "audit_records" ("row_id", "column_id", "event_type", "user", "old_value", "new_value", "created_at", "transaction_id") VALUES (values-redacted) RETURNING "id"
```

Handle this case correctly ^