### PR TITLE
Update regex for ltrim

### DIFF
--- a/lib/sql_footprint/sql_anonymizer.rb
+++ b/lib/sql_footprint/sql_anonymizer.rb
@@ -2,7 +2,7 @@ module SqlFootprint
   class SqlAnonymizer
     @rules = {
       /\sIN\s\(.*\)/ => ' IN (values-redacted)'.freeze, # IN clauses
-      /([\s\(])'.*'/ => "\\1'value-redacted'".freeze, # literal strings
+      /([\s\(])'.*?'/ => "\\1'value-redacted'".freeze, # literal strings
       /N''.*''/ => "N''value-redacted''".freeze, # literal MSSQL strings
       /\s+(!=|=|<|>|<=|>=)\s+[0-9]+/ => ' \1 number-redacted'.freeze, # numbers
       /\s+VALUES\s+\(.+\)/ => ' VALUES (values-redacted)'.freeze, # VALUES

--- a/spec/sql_footprint/sql_anonymizer_spec.rb
+++ b/spec/sql_footprint/sql_anonymizer_spec.rb
@@ -26,6 +26,14 @@ describe SqlFootprint::SqlAnonymizer do
     )
   end
 
+  it 'formats LTRIM correctly' do
+    sql = Widget.where(['LTRIM(\'  test\') = LTRIM(\'    test\')', SecureRandom.uuid]).to_sql
+    expect(anonymizer.anonymize(sql)).to eq(
+      'SELECT "widgets".* FROM "widgets" ' \
+      'WHERE (LTRIM(\'value-redacted\') = LTRIM(\'value-redacted\'))'
+    )
+  end
+
   it 'formats numbers' do
     sql = Widget.where(quantity: rand(100)).to_sql
     expect(anonymizer.anonymize(sql)).to eq(


### PR DESCRIPTION
Previously when there was an `LTRIM() = LTRIM()` in the query, it would replace the entire thing. Now it only replaces the appropriate values. Example:

Original Query: `LTRIM(value) = LTRIM(second-value)`

Before change: `LTRIM(value-redacted)`
After change: `LTRIM(value-redacted) = LTRIM(value-redacted)`