### PR TITLE
Support Rails 6.1

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+3.0.0 / 2021-05-12
+==================
+
+  * Changes to support Rails 6.1.
+  * Fetch config for database name differently because rails removed the connection_id key from the sql.active_record notification.
 
 1.0.0 / 2016-05-04
 ==================

--- a/README.md
+++ b/README.md
@@ -60,16 +60,20 @@ before do
 end
 ```
 
-Or if you're using FactoryGirl you could do something like this:
+Or if you're using FactoryBot you could do something like this:
 ```ruby
 RSpec.configure do |config|
-  module FactoryBoy
+  module FactoryKid
     def create(*args)
-      SqlFootprint.exclude { FactoryGirl.create(*args) }
+      SqlFootprint.exclude { FactoryBot.create(*args) }
     end
   end
-  config.include FactoryBoy
+  config.include FactoryKid
 end
 ```
+
+## Compatibility
+- For Rails < 6.0 compatibility, please use v2.0.1.
+- For Rails >= 6.0 compatibility, please use v3.0.0.
 
 DO NOT run SqlFootprint in production!

--- a/lib/sql_footprint.rb
+++ b/lib/sql_footprint.rb
@@ -8,9 +8,7 @@ require 'active_support/notifications'
 module SqlFootprint
   ActiveSupport::Notifications.subscribe('sql.active_record') do |_, _, _, _, payload|
     if @capture
-      adapter = ObjectSpace._id2ref(payload.fetch(:connection_id))
-      config = adapter.instance_variable_get(:@config) ||
-               adapter.instance_variable_get(:@connection_options)
+      config = payload.fetch(:connection).instance_variable_get(:@config)
       database_name = config.fetch(:database)
       capturers[database_name].capture payload.fetch(:sql)
     end

--- a/lib/sql_footprint/version.rb
+++ b/lib/sql_footprint/version.rb
@@ -1,3 +1,3 @@
 module SqlFootprint
-  VERSION = '2.0.1'.freeze
+  VERSION = '3.0.0'.freeze
 end

--- a/sql_footprint.gemspec
+++ b/sql_footprint.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activerecord', ['>= 3.0']
-  spec.add_dependency 'activesupport', ['>= 3.0']
+  spec.add_dependency 'activerecord', ['>= 6.0', '< 7.0']
+  spec.add_dependency 'activesupport', ['>= 6.0', '< 7.0']
 
   spec.add_development_dependency 'bundler', ['>= 1.7', '< 3.0']
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
### Summary 
Updates to support applications running Rails 6.1. Major version bump because apps will need to be at  activesupport/activerecord >= 6.0 to use this latest version. The gemspec is pinned accordingly.

Rails 6.1 removed the connection id from the sql.active_record notification in this [commit](https://github.com/rails/rails/commit/d140ab073f296a2a689a4dbd58cf9434c6b2a484). This caused sql footprint to fail to fetch the database name for apps running Rails >= 6.1.0. 

Although the connection id was just removed in Rails 6.1, this is compatible with Rails 6.0 because of the available payload. However, it's not compatible with versions prior to this - see following examples.

#### Rails 5.2 payload snippet
![Screen Shot 2021-05-12 at 3 16 12 PM](https://user-images.githubusercontent.com/49253356/118031863-fed56000-b334-11eb-8189-86f28ee550c6.png)

#### Rails 6.0 payload snippet
![Screen Shot 2021-05-12 at 3 21 41 PM](https://user-images.githubusercontent.com/49253356/118032507-c2eeca80-b335-11eb-8696-4c3aaf692f90.png)

#### Rails 6.1 payload snippet
![Screen Shot 2021-05-12 at 3 06 08 PM](https://user-images.githubusercontent.com/49253356/118030672-9934a400-b333-11eb-9e0e-c71bb49fdab9.png)

FactoryGirl was renamed to FactoryBot in 2017 so took this opportunity to update the readme accordingly.